### PR TITLE
Rename NFDI4Ing to NFDI4ING

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ directory.
 
 ## Acknowledgements
 
-This work is supported by [NFDI4Ing](https://nfdi4ing.de) (DFG project number 442146713).
+This work is supported by [NFDI4ING](https://nfdi4ing.de) (DFG project number 442146713).

--- a/graph/DCE.ttl
+++ b/graph/DCE.ttl
@@ -1440,7 +1440,7 @@ dce:Metadata4Ing rdf:type owl:NamedIndividual ,
                  dce:isOpenAccess "yes" ;
                  rdfs:comment "Ontology focused on the semantic description of research data in the engineering sciences"@en ;
                  owl:annotatedProperty "hostsService" ;
-                 owl:annotatedSource "NFDI4Ing" ;
+                 owl:annotatedSource "NFDI4ING" ;
                  owl:annotatedTarget "Metadata4Ing" .
 
 
@@ -1520,8 +1520,8 @@ dce:NFDI4ING_Ingest_Service rdf:type owl:NamedIndividual ,
                             dce:isOpenAccess "yes" ;
                             rdfs:comment "Repository for civil engineering, architecture and urbanism."@en ;
                             owl:annotatedProperty "hostsService" ;
-                            owl:annotatedSource "NFDI4Ing" ;
-                            owl:annotatedTarget "NFDI4Ing Ingest Service" .
+                            owl:annotatedSource "NFDI4ING" ;
+                            owl:annotatedTarget "NFDI4ING Ingest Service" .
 
 
 ###  https://data-collections.nfdi4ing.de/dce#NFDI4ING_Terminology_Service
@@ -1535,9 +1535,9 @@ dce:NFDI4ING_Terminology_Service rdf:type owl:NamedIndividual ,
                                  dce:hasServiceURL "https://terminology.nfdi4ing.de"^^xsd:anyURI ;
                                  rdfs:comment "Repository for engineering ontologies"@en ;
                                  owl:annotatedProperty "hostsService" ;
-                                 owl:annotatedSource "NFDI4Ing" ,
+                                 owl:annotatedSource "NFDI4ING" ,
                                                      "TIB" ;
-                                 owl:annotatedTarget "NFDI4Ing Terminology Service" .
+                                 owl:annotatedTarget "NFDI4ING Terminology Service" .
 
 
 ###  https://data-collections.nfdi4ing.de/dce#NIH_National_Library_of_Medicine

--- a/graph/DCE.ttl
+++ b/graph/DCE.ttl
@@ -1435,7 +1435,7 @@ dce:Metadata4Ing rdf:type owl:NamedIndividual ,
                           dce:Ontology ,
                           dce:Service ;
                  dce:hasSubjectArea dce:Engineering ;
-                 dce:isHostedBy dce:NFDI4Ing ;
+                 dce:isHostedBy dce:NFDI4ING ;
                  dce:hasServiceURL "https://w3id.org/nfdi4ing/metadata4ing"^^xsd:anyURI ;
                  dce:isOpenAccess "yes" ;
                  rdfs:comment "Ontology focused on the semantic description of research data in the engineering sciences"@en ;
@@ -1498,22 +1498,22 @@ dce:NFDI-MatWerk_Repository rdf:type owl:NamedIndividual ,
                             owl:annotatedTarget "NFDI-MatWerk Repository" .
 
 
-###  https://data-collections.nfdi4ing.de/dce#NFDI4Ing
-dce:NFDI4Ing rdf:type owl:NamedIndividual ,
+###  https://data-collections.nfdi4ing.de/dce#NFDI4ING
+dce:NFDI4ING rdf:type owl:NamedIndividual ,
                       dce:Host ;
              dce:hostsService dce:Metadata4Ing ,
-                              dce:NFDI4Ing_Terminology_Service ;
+                              dce:NFDI4ING_Terminology_Service ;
              dce:hasHostURL "https://nfdi4ing.de"^^xsd:anyURI .
 
 
-###  https://data-collections.nfdi4ing.de/dce#NFDI4Ing_Ingest_Service
-dce:NFDI4Ing_Ingest_Service rdf:type owl:NamedIndividual ,
+###  https://data-collections.nfdi4ing.de/dce#NFDI4ING_Ingest_Service
+dce:NFDI4ING_Ingest_Service rdf:type owl:NamedIndividual ,
                                      dce:Repository ,
                                      dce:Service ;
                             dce:hasSubjectArea dce:Architecture ,
                                                dce:Civil_Engineering ,
                                                dce:Urbanism ;
-                            dce:isHostedBy dce:NFDI4Ing ;
+                            dce:isHostedBy dce:NFDI4ING ;
                             dce:hasAPI "yes" ;
                             dce:hasPublicationCost "free" ;
                             dce:hasServiceURL "https://ingest.nfdi4ing.de"^^xsd:anyURI ;
@@ -1524,12 +1524,12 @@ dce:NFDI4Ing_Ingest_Service rdf:type owl:NamedIndividual ,
                             owl:annotatedTarget "NFDI4Ing Ingest Service" .
 
 
-###  https://data-collections.nfdi4ing.de/dce#NFDI4Ing_Terminology_Service
-dce:NFDI4Ing_Terminology_Service rdf:type owl:NamedIndividual ,
+###  https://data-collections.nfdi4ing.de/dce#NFDI4ING_Terminology_Service
+dce:NFDI4ING_Terminology_Service rdf:type owl:NamedIndividual ,
                                           dce:Service ,
                                           dce:Terminology_Service ;
                                  dce:hasSubjectArea dce:Interdisciplinary ;
-                                 dce:isHostedBy dce:NFDI4Ing ,
+                                 dce:isHostedBy dce:NFDI4ING ,
                                                 dce:TIB ;
                                  dce:hasAPI "yes" ;
                                  dce:hasServiceURL "https://terminology.nfdi4ing.de"^^xsd:anyURI ;
@@ -2013,7 +2013,7 @@ dce:Software rdf:type owl:NamedIndividual ,
 dce:TIB rdf:type owl:NamedIndividual ,
                  dce:Host ;
         owl:sameAs dce:Technische_Informationsbibliothek ;
-        dce:hostsService dce:NFDI4Ing_Terminology_Service ;
+        dce:hostsService dce:NFDI4ING_Terminology_Service ;
         dce:hasHostURL "https://www.tib.eu"^^xsd:anyURI .
 
 


### PR DESCRIPTION
The NFDI4ING project has a new CI which mandates uppercase spelling for the project name. Rename all occurences of NFDI4Ing to NFDI4ING.