### PR TITLE
Fix error in graph/README: remove 'Chemistry' from class hierarchy

### DIFF
--- a/graph/README.md
+++ b/graph/README.md
@@ -18,7 +18,6 @@ The structure is as follows:
         - Archive
         - Bibliography
         - Catalogue
-        - Chemistry
         - Database
         - Digital_Library
         - Encyclopedia


### PR DESCRIPTION
graph/README provides an overview of the class hierarchy of the graph. Remove 'Chemistry' from the list of services which are a collection, as 'Chemistry' is an individual of class 'SubjectArea'.