### PR TITLE
Datasets: add missing object property assertions

### DIFF
--- a/graph/DCE.ttl
+++ b/graph/DCE.ttl
@@ -459,6 +459,7 @@ dce:BioPortal rdf:type owl:NamedIndividual ,
 ###  https://data-collections.nfdi4ing.de/dce#Boreas_Dataset
 dce:Boreas_Dataset rdf:type owl:NamedIndividual ,
                             dce:Dataset ;
+                   dce:hasSubjectArea dce:Autonomous_Driving ;
                    dce:isHostedBy dce:University_of_Toronto ;
                    dce:hasAPI "yes" ;
                    dce:hasServiceURL "https://www.boreas.utias.utoronto.ca"^^xsd:anyURI ;

--- a/graph/DCE.ttl
+++ b/graph/DCE.ttl
@@ -430,6 +430,7 @@ dce:BLASTNet_Community rdf:type owl:NamedIndividual ,
 ###  https://data-collections.nfdi4ing.de/dce#BLASTNet_Simulation_Dataset
 dce:BLASTNet_Simulation_Dataset rdf:type owl:NamedIndividual ,
                                          dce:Dataset ;
+                                dce:hasSubjectArea dce:Thermal_Engineering ;
                                 dce:isHostedBy dce:BLASTNet_Community ;
                                 dce:hasAPI "yes" ;
                                 dce:hasPublicationCost "no" ;

--- a/graph/DCE.ttl
+++ b/graph/DCE.ttl
@@ -2492,6 +2492,7 @@ dce:nuImages rdf:type owl:NamedIndividual ,
 ###  https://data-collections.nfdi4ing.de/dce#nuPlan
 dce:nuPlan rdf:type owl:NamedIndividual ,
                     dce:Dataset ;
+           dce:hasSubjectArea dce:Autonomous_Driving ;
            dce:isHostedBy dce:Motional ;
            dce:hasAPI "no" ;
            dce:hasServiceURL "https://www.nuscenes.org/nuplan"^^xsd:anyURI ;

--- a/graph/DCE.ttl
+++ b/graph/DCE.ttl
@@ -2361,6 +2361,7 @@ dce:Woven_by_Toyota_Perception_Dataset rdf:type owl:NamedIndividual ,
 dce:Woven_by_Toyota_Prediction_Dataset rdf:type owl:NamedIndividual ,
                                                 dce:Dataset ;
                                        dce:hasSubjectArea dce:Autonomous_Driving ;
+                                       dce:isHostedBy <https://data-collections.nfdi4ing.de/dce#Woven_by_Toyota,_Inc.> ;
                                        dce:hasAPI "no" ;
                                        dce:hasServiceURL "https://woven.toyota/en/prediction-dataset"^^xsd:anyURI ;
                                        dce:isOpenAccess "yes" ;


### PR DESCRIPTION
Add missing object property assertions:
- set subject area of the BLASTNet Simulation Dataset to Thermal Engineering
- set subject area of the Boreas Dataset to Autonomous Driving
- set subject area of nuPlan to Autonomous Driving
- set host of Woven by Toyota Prediction Dataset to Woven by Toyota, Inc.